### PR TITLE
Add OSRM routing building blocks, fixes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,21 @@ Now the the files will be formatted at every `git commit`.
 This code in this repository has a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license.
 This license requires that reusers give credit to the creator(s). It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, for noncommercial purposes only. If others modify or adapt the material, they must license the modified material under identical terms.
 
+## External resources
+
+The main program from this repository may use the [public OSRM service](https://routing.openstreetmap.de/about.html) by
+[FOSSGIS](https://www.fossgis.de/). They offer routing services under [certain
+conditions](https://www.fossgis.de/arbeitsgruppen/osm-server/nutzungsbedingungen/), to name a few (technical) ones:
+
+- a valid HTTP User-Agent
+- a maximum of one request per second
+- commercial usage prohibited, unless they do not constitute an essential part of the commercial offer
+- no high volume
+- no bulk downloading of data
+
+The main program in this repository respects these conditions. Consequently, the execution of the program may take a while. Please
+do not change the limitations in place to keep the provider of this service happy.
+
+Furthermore, the data provided is © [OpenStreetMap](https://www.openstreetmap.org/copyright) and their contributors under
+[ODbL](https://opendatacommons.org/licenses/odbl/index.html) and [CC-BY-SA](https://creativecommons.org/licenses/by-sa/2.0/).
+Please contribute to OpenStreetMap by [fixing the map](https://openstreetmap.org/fixthemap).

--- a/clothing_loop/main.py
+++ b/clothing_loop/main.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser
 
 from data_io import read_participants
 from locations import get_locations
+from osrm import get_route
 
 
 def init_argument_parser():
@@ -40,6 +41,14 @@ def init_argument_parser():
         help="Store the output CSV in this filename, or - for standard output, default: %(default)s",
         default="-",
     )
+    argparser.add_argument(
+        "-r",
+        "--route",
+        dest="fetchroute",
+        help="Query OSRM for routing decisions, default: %(default)s",
+        action="store_true",
+        default=False,
+    )
     return argparser
 
 
@@ -56,6 +65,7 @@ def main():
         print(f"[DBG] read_participants({args.infile}):", file=sys.stderr)
         pprint.pprint(participants, stream=sys.stderr)
 
+    locations = []
     if args.fetchosm:
         if args.debug:
             print(
@@ -66,6 +76,18 @@ def main():
         if args.debug:
             print("[DBG] get_locations(participants):", file=sys.stderr)
             pprint.pprint(locations, stream=sys.stderr)
+
+    if args.fetchroute:
+        wps = [
+            {"latitude": loc.latitude, "longitude": loc.longitude} for loc in locations
+        ]
+        if args.debug:
+            print(wps)
+        distance = get_route(wps)
+        print(f"Expected distance: {distance} meters")
+        print(
+            "Routing provided by FOSSGIS, data © OpenStreetMap, ODbL, CC-BY-SA, contribute: https://openstreetmap.org/fixthemap"
+        )
 
 
 if __name__ == "__main__":

--- a/clothing_loop/osrm.py
+++ b/clothing_loop/osrm.py
@@ -1,0 +1,48 @@
+import time
+from random import randint
+
+import requests
+
+# We explicitly want walking directions, so we use /routed-foot/
+OSRM_ENDPOINT = "https://routing.openstreetmap.de/routed-foot/route/v1/driving/"
+OSRM_LAST_REQUEST = None
+
+
+def get_route(waypoints):
+    if len(waypoints) <= 1:
+        raise Exception("Need at least 2 waypoints to get a route")
+
+    for wp in waypoints:
+        if not isinstance(wp, dict):
+            raise Exception(
+                f"Waypoint {wp} is not a dict, expecting {'latitude': 51.48, 'longitude': 0.00}"
+            )
+
+    locs = [f"{wp['longitude']},{wp['latitude']}" for wp in waypoints]
+    uri = ";".join(locs)
+    return osrm_parse(osrm_request(uri))
+
+
+def osrm_parse(req_json):
+    # TODO: parse req_json.code
+    # TODO: check for number of returned routes
+    return req_json["routes"][0]["distance"]
+
+
+def osrm_request(uri):
+    global OSRM_LAST_REQUEST
+
+    if OSRM_LAST_REQUEST is None:
+        OSRM_LAST_REQUEST = time.time_ns() - int(1e9) - 1
+
+    now = time.time_ns()
+    if OSRM_LAST_REQUEST + int(1e9) < now:
+        # Requests are limited to 1 per second, wait a bit
+        time.sleep(1.2)
+
+    user_agent = "clothing_loop_{}".format(
+        randint(10000, 99999)
+    )  # TODO: set user-agent globally
+    req = requests.get(OSRM_ENDPOINT + uri, headers={"user-agent": user_agent})
+    req.raise_for_status()  # raise Exception when status code is 4xx or 5xx
+    return req.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ geopy==2.2.0
 numpy==1.23.4
 pre-commit==2.20.0
 python-tsp==0.3.1
+requests==2.28.1


### PR DESCRIPTION
Output based on the example data:

```
$ python main.py -i ../example_data/participants.csv -g -d -r
[DBG] read_participants(../example_data/participants.csv):
[..]
[{'latitude': 51.8433956, 'longitude': 5.8643101}, {'latitude': 51.8152491, 'longitude': 5.8514569}, {'latitude': 51.8454346, 'longitude': 5.8644696}, {'latitude': 51.8431339, 'longitude': 5.8613668}, {'latitude': 51.8473778, 'longitude': 5.861643}, {'latitude': 51.8430394, 'longitude': 5.86248}, {'latitude': 51.8487504, 'longitude': 5.8644206}, {'latitude': 51.8479247, 'longitude': 5.8635052}, {'latitude': 51.8361658, 'longitude': 5.8782252}, {'latitude': 51.8479623, 'longitude': 5.863836}, {'latitude': 51.8357071, 'longitude': 5.8745025}, {'latitude': 51.8489141, 'longitude': 5.862433}]
Expected distance: 17980.5 meters
Routing provided by FOSSGIS, data © OpenStreetMap, ODbL, CC-BY-SA, contribute: https://openstreetmap.org/fixthemap
```

This PR contains a few TODOs to make the parsing of routing data more robust. The notice that routing is provided by FOSSGIS may be improved as well (see the supplied `README.md` changes).